### PR TITLE
Template link handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,6 +73,9 @@ def uuid():
     return "{}".format(uuid4().hex)
 app.jinja_env.globals.update(uuid=uuid)
 
+def url_is(endpoint):
+    return request.endpoint == endpoint
+app.jinja_env.globals.update(url_is=url_is)
 
 # This route needs to live here forever because it requires access to the app.
 @app.route('/api', methods=["GET"])

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from . import user, course, lesson, object, error, log, segment
+from . import user, course, lesson, object, error, log, segment, pages
 
 def attach(app):
     app.register_blueprint(user.blueprint)
@@ -9,6 +9,8 @@ def attach(app):
     app.register_blueprint(object.blueprint)
     app.register_blueprint(error.blueprint)
     app.register_blueprint(log.blueprint)
+    pages.attach_static_paths(app, 'templates/static')
+    app.register_blueprint(pages.blueprint)
 
 def dump_api(app):
     """

--- a/routes/course.py
+++ b/routes/course.py
@@ -20,7 +20,7 @@ def view(slug):
     return render_template('course_intro.html', course=course)
 
 @blueprint.route('/code', methods=["GET", "POST"])
-def by_code():
+def code():
     error = None
     if request.method == "POST":
         c = datamodels.get_course_by_code(request.form['course_code'])

--- a/routes/pages.py
+++ b/routes/pages.py
@@ -2,6 +2,7 @@ from glob import glob
 import re
 from functools import wraps
 from flask import Blueprint, render_template, session, request, url_for, redirect, flash
+import datamodels
 
 blueprint = Blueprint('pages', __name__)
 

--- a/routes/pages.py
+++ b/routes/pages.py
@@ -1,0 +1,57 @@
+from glob import glob
+import re
+from functools import wraps
+from flask import Blueprint, render_template, session, request, url_for, redirect, flash
+
+blueprint = Blueprint('pages', __name__)
+
+@blueprint.route('/')
+def index():
+    """ Shows all courses the user has access to. """
+    data = {'public_courses': datamodels.get_public_courses()}
+    return render_template('welcome.html', **data)
+
+########
+# Maybe a bit too much magic; best not to look past this comment.
+########
+
+def _bind_render(s, p):
+    def fun():
+        return render_template('static/{}/{}.html'.format(s, p))
+    return fun
+
+def get_static_paths(relative_path):
+    """
+    Do a glob on static template files and organize them by section.
+    """
+    paths = {}
+    for l in glob('{}/**/*.html'.format(relative_path)):
+        l = re.sub(r"^{}\/".format(relative_path), '', l)  # Base path
+        l = re.sub(r"\.html$", '', l)  # Strip file extension
+        l = l.split('/')
+        if l[0] not in paths:
+            paths[l[0]] = []
+        paths[l[0]].append(l[1])
+    return paths
+
+def attach_static_paths(app, relative_path):
+    """
+    Make url_for paths for all the static pages so we can do active link
+    stuff.
+    """
+    paths = get_static_paths(relative_path)
+    for section, pages in paths.items():
+        bp = Blueprint(section, section)
+        for page in pages:
+            if page == "index":
+                path = '/{}'.format(section)
+            else:
+                path = '/{}/{}'.format(section, page)
+            f = _bind_render(section, page)
+            bp.add_url_rule(path, page, f)
+        app.register_blueprint(bp)
+    @blueprint.route('/static')
+    def sitemap():
+        if app.debug is not True:
+            return redirect('404')
+        return render_template('static/sitemap.html', pages=paths)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,3 +1,4 @@
+{% from 'macros.html' import link_to, active_link %}
 <!doctype html>
 <html lang="en" class="">
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,7 @@
+{% macro link_to(endpoint, title) -%}
+    <a href="{{ url_for(endpoint) }}" class="{{ 'active' if url_is(endpoint) }}">{{ title }}</a>
+{%- endmacro %}
+
+{% macro active_link(endpoint) -%}
+	{{ 'active' if url_is(endpoint) }}
+{%- endmacro %}

--- a/templates/partials/_course_code.html
+++ b/templates/partials/_course_code.html
@@ -1,4 +1,4 @@
-<form class="fit_form_code fit_fancyplace fit_wiggle_daddy" method="post" action="/code">
+<form class="fit_form_code fit_fancyplace fit_wiggle_daddy" method="post" action="{{ url_for('course.code') }}">
 	<div class="form-group">
 	  <input type="text" class="form-control" name="course_code" id="course_code" placeholder="Course code" required data-fit-fancyplace>
 	  <label for="course_code">Course code</label>

--- a/templates/partials/_login_form.html
+++ b/templates/partials/_login_form.html
@@ -12,7 +12,7 @@
   <div class="tab-content" id="tabContent">
     <div class="tab-pane fade" id="login" role="tabpanel" aria-labelledby="login-tab">
       {% include 'partials/_form_errors.html' %}
-      <form class="form" action="/login" method="post">
+      <form class="form" action="{{ url_for('user.login') }}" method="post">
         <div class="fit_fancyplace">
           <label for="inputEmail">Email address</label>
           <input type="email" id="inputEmail" name="email" class="form-control" placeholder="Email address" required autofocus data-fit-fancyplace>
@@ -32,7 +32,7 @@
     </div><!-- login -->
 
     <div class="tab-pane fade show active" id="register" role="tabpanel" aria-labelledby="register-tab">
-      <form class="form" action="/register" method="post">
+      <form class="form" action="{{ url_for('user.create') }}" method="post">
         <div class="row">
           <div class="col-sm-6">
             <div class="fit_fancyplace">
@@ -65,7 +65,7 @@
             </div>
             <input type="text" id="username" class="form-control" maxlength="20" name="username" value="" placeholder="username" aria-label="username" aria-describedby="basic-addon1" required data-fit-userslug_set>
           </div>
-          <small class="form-text text-muted">Your link will be: <br><a href="/user/clarecarmody">fitzroyacademy.com/user/<strong data-fit-userslug></strong></a></small>
+          <small class="form-text text-muted">Your link will be: <br><a href="{{ url_for('user.view', slug='clarecarmody') }}">fitzroyacademy.com/user/<strong data-fit-userslug></strong></a></small>
           <input type="hidden" value="clarecarmody" id="secretslug" name="secretslug" data-fit-userslug_secret>
         </div>
 

--- a/templates/partials/_nav_code.html
+++ b/templates/partials/_nav_code.html
@@ -4,7 +4,7 @@
     {% include 'partials/_chrome_fa_svg.html' %}
   </a>
 
-  <form class="fit_form_code_head fit_fancyplace" method="post" action="/code" data-fit_head_code_daddy>
+  <form class="fit_form_code_head fit_fancyplace" method="post" action="{{ url_for('course.code') }}" data-fit_head_code_daddy>
 	  <div class="input-group input-group-sm">
 		  <input type="text" name="course_code" id="course_code_header" class="form-control" placeholder="Course code" aria-label="Coure code" data-fit_head_code data-fit-fancyplace>
 		  <div class="input-group-append">
@@ -18,7 +18,7 @@
 
     <div class="right fit_mobile_menu">
 
-      <a href="/" class="fit_btn fit_mobile_menu_trigger" data-fit_mobile_menu_trigger>
+      <a href="{{ url_for('index') }}" class="fit_btn fit_mobile_menu_trigger" data-fit_mobile_menu_trigger>
         <span class="fit_txt">Menu</span>
         <i class="fal fa-chevron-down"></i>
         <i class="fal fa-times"></i>
@@ -41,7 +41,7 @@
         </a>
 
         
-          <a href="/login" class="fit_btn" data-fit-userpanel>
+          <a href="{{ url_for('user.login') }}" class="fit_btn" data-fit-userpanel>
             <span class="fit_txt">Sign up</span>
             <i class="fal fa-user"></i>
           </a>

--- a/templates/partials/_nav_footer.html
+++ b/templates/partials/_nav_footer.html
@@ -4,7 +4,7 @@
 
       <div class="row">
         <div class="col-sm">
-          <a href="/" class="fit_device">
+          <a href="{{ url_for('index') }}" class="fit_device">
             {% include 'partials/_chrome_fa_svg.html' %}
           </a>
         </div>
@@ -25,8 +25,8 @@
         </div>
         <div class="col-sm">
           <div class="fit_footer_nav">
-            <a href="support" class="note"><small>Need help?</small>Get support</a>
-            <a href="about/michael#">In loving memory</a>
+            <a href="{{ url_for('support.index') }}" class="note {{ active_link('support.index') }}"><small>Need help?</small>Get support</a>
+            {{ link_to('about.michael', 'In loving memory') }}</a>
           </div>
         </div>
       </div>

--- a/templates/partials/static_menus/_about.html
+++ b/templates/partials/static_menus/_about.html
@@ -1,7 +1,7 @@
-<a href="/about">About</a>
+{{ link_to('about.index', 'About')}}
 <a href="/about/impact">Impact</a>
 <a href="/about/partners">Partners</a>
-<a href="/about/mistakes">Mistakes</a>
+{{ link_to('about.mistakes', 'Mistakes')}}
 <a href="/about/jobs">Jobs</a>
 <a href="/contact">Contact</a>
 <a href="https://medium.com/fitzroy-academy">Blog <i class="far fa-external-link"></i></a>

--- a/templates/partials/static_menus/_product.html
+++ b/templates/partials/static_menus/_product.html
@@ -1,5 +1,5 @@
-<a href="product">Product</a>
+{{ link_to("product.index", "Product")}}
 <a href="product/pricing">Pricing</a>
-<a href="product/resources">Resources</a>
+{{ link_to("product.resources", "Resources")}}
 <a href="product/case">Case studies</a>
 <a href="product/resources">Security</a>

--- a/templates/partials/static_menus/_support.html
+++ b/templates/partials/static_menus/_support.html
@@ -1,3 +1,4 @@
+{{ link_to("support.index", "Support") }}
 <a href="support/resources">Terms</a>
 <a href="support/privacy">Privacy</a>
 <a href="support/conduct">Conduct</a>

--- a/templates/static/sitemap.html
+++ b/templates/static/sitemap.html
@@ -1,0 +1,29 @@
+{% extends "/layout.html" %}
+{% block body %}
+
+<main>
+
+  <article>
+
+  <div class="fit_medium">
+
+    <h1>Static Pages</h1>
+
+    <p>These pages live in the <code>./templates/static/</code> directory.</p>
+
+    {% for section, pages in pages.items(): %}
+      <h3>{{ section }}</h3>
+      	<ul>
+      	{% for page in pages %}
+      		<li><code><a href="{{ url_for(section+'.'+page) }}">url_for("{{section}}.{{page}}")</a></code></li>
+      	{% endfor %}
+      	</ul>
+    {% endfor %}
+
+  </div>
+
+  </article>
+
+</main>
+
+{% endblock %}

--- a/templates/static/sitemap.html
+++ b/templates/static/sitemap.html
@@ -11,11 +11,13 @@
 
     <p>These pages live in the <code>./templates/static/</code> directory.</p>
 
+    <p><strong>NB:</strong> All endpoints (like <code>support.index</code>) must exist by having HTML files within the templates/static directories or the link macros will throw a template error.</p>
+
     {% for section, pages in pages.items(): %}
       <h3>{{ section }}</h3>
       	<ul>
       	{% for page in pages %}
-      		<li><code><a href="{{ url_for(section+'.'+page) }}">url_for("{{section}}.{{page}}")</a></code></li>
+      		<li><code><a href="{{ url_for(section+'.'+page) }}">url_for("{{section}}.{{page}}") -> {{ url_for(section+'.'+page) }}</a></code></li>
       	{% endfor %}
       	</ul>
     {% endfor %}

--- a/templates/static/sitemap.html
+++ b/templates/static/sitemap.html
@@ -15,11 +15,11 @@
 
     {% for section, pages in pages.items(): %}
       <h3>{{ section }}</h3>
-      	<ul>
-      	{% for page in pages %}
-      		<li><code><a href="{{ url_for(section+'.'+page) }}">url_for("{{section}}.{{page}}") -> {{ url_for(section+'.'+page) }}</a></code></li>
-      	{% endfor %}
-      	</ul>
+        <ul>
+        {% for page in pages %}
+          <li><code>url_for("{{section}}.{{page}}")</code> -> <a href="{{ url_for(section+'.'+ page) }}">{{ url_for(section+'.'+page) }}</a></li>
+        {% endfor %}
+        </ul>
     {% endfor %}
 
   </div>


### PR DESCRIPTION
So this PR adds a few things.

# Template Macros

## link_to(endpoint)

For nonfancy links.

```.html
{{ link_to('about.index', 'About')}}
```

Expands to:

```.html
<a href="{{ url_for('about.index') }}" 
  class="{{ 'active' if url_is('about.index') }}">About</a>
```

## url_for / active_link

For roll-your-own.

```.html
<a href="{{ url_for('support.index') }}" 
  class="note {{ active_link('support.index') }}"
  data-fit-some-other-fancy-thing>
  <small>Need help?</small>Get support</a>
```

Expands to:

```.html
<a href="/support" class="note {{ 'active' if url_is('support.index') }}" 
  data-fit-some-other-fancy-thing>
  <small>Need help?</small>Get support</a>
```

# Debug Route: /static

We also have a handy debug page to list all the valid static pages, much like `/api`.

![](https://user-images.githubusercontent.com/13204/61574801-93047200-aa92-11e9-8cd0-b9604a62a333.png)


*NB:* All endpoints (like `support.index`) must exist by having HTML files within the `templates/static` directories or the link macros will throw a template error.