### PR TITLE
Add function and params for static file s3 upload

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config(object):
 	DB_OPTIONS = environ.get("DB_OPTIONS", default='')
 	MAILGUN_API_URL = environ.get("MAILGUN_API_URL", default=None)
 	MAILGUN_API_KEY = environ.get("MAILGUN_API_KEY", default=None)
+	S3_BUCKET = environ.get("S3_BUCKET", default=None)
 
 	@property
 	def DB_URI(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2==2.8.3
 nose==1.3.7
 requests==2.22.0
 coverage==4.5.4
+boto3==1.9.225


### PR DESCRIPTION
This will allow local testing and file upload via the app (for images, etc). Provided an example function which can be moved or repurposed anywhere in the code as needed. An environment variable is there so we can tell different deployments to upload to different buckets (for separate customers, or environments if we desire).

Also added boto3 to requirements.txt, which will require a `pip3 install -r requirements.txt` from @willdayble once it's in master.